### PR TITLE
Fix background color in File list, Search and Search spy frames

### DIFF
--- a/client/DirectoryListing.h
+++ b/client/DirectoryListing.h
@@ -53,7 +53,10 @@ class DirectoryListing : public UserInfoBase
 			FLAG_HAS_CANCELED   = 1 << 7,
 			FLAG_HAS_OTHER      = 1 << 8,
 			FLAG_FOUND          = 1 << 9, // files and dirs
-			FLAG_HAS_FOUND      = 1 << 10  // dirs only
+			FLAG_HAS_FOUND      = 1 << 10, // dirs only
+
+			FLAG_MASK_FIXED_TEXT_COLOR_DIR = FLAG_FOUND | FLAG_HAS_FOUND | FLAG_HAS_SHARED | FLAG_HAS_DOWNLOADED | FLAG_HAS_CANCELED,
+			FLAG_MASK_FIXED_TEXT_COLOR_FILE = FLAG_FOUND | FLAG_HAS_FOUND | FLAG_SHARED | FLAG_DOWNLOADED | FLAG_CANCELED
 		};
 		
 		struct MediaInfo

--- a/client/SearchResult.h
+++ b/client/SearchResult.h
@@ -123,7 +123,9 @@ class SearchResult : public SearchResultCore
 			FLAG_SHARED            = 0x02,
 			FLAG_QUEUED            = 0x04,
 			FLAG_DOWNLOADED        = 0x08,
-			FLAG_DOWNLOAD_CANCELED = 0x10
+			FLAG_DOWNLOAD_CANCELED = 0x10,
+
+			FLAG_MASK_FIXED_TEXT_COLOR = FLAG_SHARED | FLAG_DOWNLOADED | FLAG_DOWNLOAD_CANCELED | FLAG_QUEUED
 		};
 
 		SearchResult() : flags(0), token(uint32_t (-1)), ip{0}

--- a/windows/DirectoryListingFrm.cpp
+++ b/windows/DirectoryListingFrm.cpp
@@ -2131,8 +2131,8 @@ LRESULT DirectoryListingFrame::onSpeaker(UINT /*uMsg*/, WPARAM wParam, LPARAM lP
 
 void DirectoryListingFrame::getDirItemColor(const Flags::MaskType flags, COLORREF &fg, COLORREF &bg)
 {
-	fg = RGB(0,0,0);
-	bg = RGB(255,255,255);
+	fg = (flags & DirectoryListing::FLAG_MASK_FIXED_TEXT_COLOR_DIR) ? RGB(0,0,0) : ctrlTree.GetTextColor();
+	bg = ctrlTree.GetBkColor();
 	if (flags & DirectoryListing::FLAG_FOUND)
 		bg = colorFound; else
 	if (flags & DirectoryListing::FLAG_HAS_FOUND)
@@ -2159,13 +2159,16 @@ void DirectoryListingFrame::getDirItemColor(const Flags::MaskType flags, COLORRE
 			bg = colorCanceled;
 	}
 	if (flags & DirectoryListing::FLAG_HAS_QUEUED)
+	{
 		fg = colorInQueue;
+		bg = RGB(255,255,255);
+	}
 }
 
 void DirectoryListingFrame::getFileItemColor(const Flags::MaskType flags, COLORREF &fg, COLORREF &bg)
 {
-	fg = RGB(0,0,0);
-	bg = RGB(255,255,255);
+	fg = (flags & DirectoryListing::FLAG_MASK_FIXED_TEXT_COLOR_FILE) ? RGB(0,0,0) : ctrlList.GetTextColor();
+	bg = ctrlList.GetTextBkColor();
 	if (flags & DirectoryListing::FLAG_FOUND)
 		bg = colorFound; else
 	if (flags & DirectoryListing::FLAG_HAS_FOUND)
@@ -2177,7 +2180,10 @@ void DirectoryListingFrame::getFileItemColor(const Flags::MaskType flags, COLORR
 	if (flags & DirectoryListing::FLAG_CANCELED)
 		bg = colorCanceled;
 	if (flags & DirectoryListing::FLAG_QUEUED)
+	{
 		fg = colorInQueue;
+		bg = RGB(255,255,255);
+	}
 }
 
 LRESULT DirectoryListingFrame::onCustomDrawList(int /*idCtrl*/, LPNMHDR pnmh, BOOL& /*bHandled*/)

--- a/windows/SearchFrm.cpp
+++ b/windows/SearchFrm.cpp
@@ -3111,8 +3111,8 @@ static inline void getFileItemColor(int flags, COLORREF& fg, COLORREF& bg)
 	static const COLORREF colorDownloaded = RGB(145,194,196);
 	static const COLORREF colorCanceled = RGB(210,168,211);
 	static const COLORREF colorInQueue = RGB(186,0,42);
-	fg = RGB(0,0,0);
-	bg = RGB(255,255,255);
+	fg = (flags & SearchResult::FLAG_MASK_FIXED_TEXT_COLOR) ? RGB(0,0,0) : Colors::g_textColor;
+	bg = Colors::g_bgColor;
 	if (flags & SearchResult::FLAG_SHARED)
 		bg = colorShared; else
 	if (flags & SearchResult::FLAG_DOWNLOADED)
@@ -3120,7 +3120,10 @@ static inline void getFileItemColor(int flags, COLORREF& fg, COLORREF& bg)
 	if (flags & SearchResult::FLAG_DOWNLOAD_CANCELED)
 		bg = colorCanceled;
 	if (flags & SearchResult::FLAG_QUEUED)
+	{
 		fg = colorInQueue;
+		bg = RGB(255,255,255);
+	}
 }
 
 LRESULT SearchFrame::onCustomDraw(int /*idCtrl*/, LPNMHDR pnmh, BOOL& /*bHandled*/)

--- a/windows/SpyFrame.cpp
+++ b/windows/SpyFrame.cpp
@@ -92,6 +92,7 @@ LRESULT SpyFrame::onCreate(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*lParam*/, 
 	ctrlSearches.Create(m_hWnd, rcDefault, NULL, WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN |
 	                    WS_HSCROLL | WS_VSCROLL | LVS_REPORT | LVS_SHOWSELALWAYS | LVS_SINGLESEL, WS_EX_CLIENTEDGE, IDC_RESULTS);
 	ctrlSearches.SetExtendedListViewStyle(WinUtil::getListViewExStyle(false));
+	ctrlSearches.SetBkColor(Colors::g_bgColor);
 	hTheme = OpenThemeData(m_hWnd, L"EXPLORER::LISTVIEW");
 	if (hTheme)
 		customDrawState.flags |= CustomDrawHelpers::FLAG_APP_THEMED;
@@ -469,9 +470,10 @@ LRESULT SpyFrame::onCustomDraw(int /*idCtrl*/, LPNMHDR pnmh, BOOL& /*bHandled*/)
 
 		case CDDS_ITEMPREPAINT:
 		{
-			cd->clrText = RGB(0,0,0);
-			cd->clrTextBk = RGB(255,255,255);
 			const ItemInfo* ii = reinterpret_cast<ItemInfo*>(cd->nmcd.lItemlParam);
+			bool force_text_Color = (ii->re == ClientManagerListener::SEARCH_HIT || ii->re == ClientManagerListener::SEARCH_PARTIAL_HIT);
+			cd->clrText = force_text_Color ? RGB(0,0,0) : Colors::g_textColor;
+			cd->clrTextBk = Colors::g_bgColor;
 			if (ii->re == ClientManagerListener::SEARCH_HIT)
 				cd->clrTextBk = colorShared;
 			else if (ii->re == ClientManagerListener::SEARCH_PARTIAL_HIT)


### PR DESCRIPTION
Background color is not consistent across frames when using custom color scheme.

This removes hardcoded bg colors where possible.