### PR TITLE
Fix socket expiration condition in SocketPool

### DIFF
--- a/client/SocketPool.cpp
+++ b/client/SocketPool.cpp
@@ -168,7 +168,7 @@ void SocketPool::removeExpired(uint64_t tick) noexcept
 	for (auto i = socketsByPort.begin(); i != socketsByPort.end();)
 	{
 		const SocketInfoPtr& si = i->second;
-		if (si->expires < tick)
+		if (si->expires > tick)
 		{
 			++i;
 			continue;


### PR DESCRIPTION
When `expires < tick`, the socket IS expired and should be deleted. But the code skips it (`++i; continue`). When `expires > tick` (socket is still valid), the code falls through and deletes it. The logic is reversed.

This function is called from a periodic timer at `windows/MainFrm.cpp:867` (`socketPool.removeExpired(tick)`) which fires once per minute.